### PR TITLE
Removed support for PHP 7.4, added badges to README, and updated workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest, ubuntu-20.04 ]
-        php: [ '7.4', '8.0' ]
+        php: [ '8.0', '8.1']
         redis-version: [4, 5, 6]
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Codeception tests
+name: Codeception Tests
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 kodus/predis-simple-cache
 =========================
+[![PHP Version](https://img.shields.io/badge/php-8.0%2B-blue.svg)](https://packagist.org/packages/kodus/predis-simple-cache)
+![Build Status](https://github.com/kodus/predis-simple-cache/actions/workflows/test.yml/badge.svg)
 
 A lightweight bridge from [predis/predis](https://packagist.org/packages/predis/predis) to the 
 [PSR-16 simple-cache interface](https://www.php-fig.org/psr/psr-16/)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4|^8.0",
+        "php": ">=8.0",
         "psr/simple-cache": "^1.0",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
* Removed support for PHP 7.4
* Added badges to the README
* Updated workflow yaml file
* The plan is to release this as version 1.1.0 if approved
* I will open 2 new PRs for simple-cache version 2.0 and 3.0 next.

(I accidentally wrote that I updated travis.yml in the commit message... I can't think straight in this heat :sweat_smile:)